### PR TITLE
function require_once in few subtemplates

### DIFF
--- a/Quicky_compiler.class.php
+++ b/Quicky_compiler.class.php
@@ -1251,7 +1251,7 @@ class Quicky_compiler {
 					}
 				}
 				if (!$b) {
-					$c = in_array($a, $this->template_defined_functions)/* || function_exists('quicky_function_' . $a)*/;
+					$c = in_array($a, $this->template_defined_functions);
 				}
 				if (!$b and !$c) {
 					$y = $this->_alt_tag && !in_array($a, get_class_methods('Quicky'));

--- a/Quicky_compiler.class.php
+++ b/Quicky_compiler.class.php
@@ -1251,7 +1251,7 @@ class Quicky_compiler {
 					}
 				}
 				if (!$b) {
-					$c = in_array($a, $this->template_defined_functions) || function_exists('quicky_function_' . $a);
+					$c = in_array($a, $this->template_defined_functions)/* || function_exists('quicky_function_' . $a)*/;
 				}
 				if (!$b and !$c) {
 					$y = $this->_alt_tag && !in_array($a, get_class_methods('Quicky'));


### PR DESCRIPTION
если у нас подключаются два подшаблона с использованием функции из папки плагинов, то require_once происходит только в первом, во втором считается что функция уже есть и не подключается. далее, при использовании второго подшаблона в другом месте (без первого), получается что функции в нем нет.